### PR TITLE
Mobile ux

### DIFF
--- a/browserScripts/browser.coffee
+++ b/browserScripts/browser.coffee
@@ -44,7 +44,8 @@ $(document).ready ->
   $(".tetrisButton").on "click" , (e)->
     e.preventDefault()
     if $(@).hasClass('tetrisButton')
-      $(@).find('.tetrisControls').show()
+      $(".tetrisControls").show()
+      $('html, body').animate({scrollTop:$(document).height()}, 'fast')
       submitDoc = {}
       submitDoc["show"] = $(@).text()
       submitDoc["colorArray"] = colors

--- a/index.coffee
+++ b/index.coffee
@@ -47,6 +47,10 @@ WebServer.listen port, ->
     res.send "tetrising!"
 
 indexTemplate = ->
+  head ->
+    title 'Sidewalk Controller'
+    meta name: 'viewport', content: 'width=device-width,
+    initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'
   div class:"container",->
     link rel:"stylesheet",href:"bundle.css"
     h1 "DECENTRAL"
@@ -66,15 +70,15 @@ indexTemplate = ->
 
     button class:'tetrisButton btn btn-primary btn-lg col-xs-12', ->
       text 'Tetris'
-      div class:'tetrisControls', ->
-        div class: 'ROTATE' , ->
-          i class:"glyphicon glyphicon-retweet col-xs-12"
-        div class:'LEFT' , ->
-          i class:"glyphicon glyphicon-arrow-left col-xs-6"
-        div class:'RIGHT', ->
-          i class:"glyphicon glyphicon-arrow-right col-xs-6"
-        div class: 'DOWN' , ->
-          i class:"glyphicon glyphicon-arrow-down col-xs-12"
+    div class:'tetrisControls', ->
+      div class: 'ROTATE' , ->
+        i class:"glyphicon glyphicon-retweet col-xs-12"
+      div class:'LEFT' , ->
+        i class:"glyphicon glyphicon-arrow-left col-xs-6"
+      div class:'RIGHT', ->
+        i class:"glyphicon glyphicon-arrow-right col-xs-6"
+      div class: 'DOWN' , ->
+        i class:"glyphicon glyphicon-arrow-down col-xs-12"
   script src:"bundle.js"
 
 indexHtml = ck.render indexTemplate

--- a/opc_controllers/tetris.js
+++ b/opc_controllers/tetris.js
@@ -309,7 +309,7 @@ TETRIS = function Tetris(stream, strand, score_callback) {
 
     function update_board() {
       move_down();
-      t = setTimeout(function() { update_board(); }, 50 - (5 * level));
+      t = setTimeout(function() { update_board(); }, 150 - (5 * level));
     }
 
     function initialize() {

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,7 +5,7 @@ body{
 
 .container{
 	background-color: black;
-  width: 100%;
+	width: 100%;
 }
 
 h1{

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,6 +5,7 @@ body{
 
 .container{
 	background-color: black;
+  width: 100%;
 }
 
 h1{
@@ -51,7 +52,7 @@ float:left;
 }
 .tetrisControls{
 	font-size: 5em;
-	color: black;
+	color: white;
 	border-radius: 100%
 	border-style:solid;
 	min-height: 50px;


### PR DESCRIPTION
A few tweaks to the interface to get it more usable on mobile where it (tetris at least) will likely be used.
Disabled zooming which was messing with double-clicks on android-chrome.
Dropped tetris controls outside of bootstrap button div, they weren't responding properly on android-firefox. This makes them taller and more clickable as a bonus.
Scroll window on controls .show() - Previously this was happening off-screen on mobile so user may not have seen the addition of the new buttons.
